### PR TITLE
Methods and fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cp ./filetype.vim $VIMDIR
 ## Configuration
 You can add any of following into Yours vim config to disable highlighting. All options are enabled by default.
 
-```vi
+```vim
 let g:v_highlight_array_whitespace_error = 0
 let g:v_highlight_chan_whitespace_error = 0
 let g:v_highlight_extra_types = 0
@@ -43,7 +43,6 @@ let g:v_highlight_trailing_whitespace_error = 0
 let g:v_highlight_function_calls = 0
 let g:v_highlight_fields = 0
 ```
-
 
 ## A Note about Verilog
 The language Verilog also uses the file extensions \*.v and \*.vh, which causes

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ Otherwise, copy the file ./filetype.vim into $VIMDIR:
 cp ./filetype.vim $VIMDIR
 ```
 
+## Configuration
+You can add any of following into Yours vim config to disable highlighting. All options are enabled by default.
+
+```vi
+let g:v_highlight_array_whitespace_error = 0
+let g:v_highlight_chan_whitespace_error = 0
+let g:v_highlight_extra_types = 0
+let g:v_highlight_space_tab_error = 0
+let g:v_highlight_trailing_whitespace_error = 0
+let g:v_highlight_function_calls = 0
+let g:v_highlight_fields = 0
+```
+
+
 ## A Note about Verilog
 The language Verilog also uses the file extensions \*.v and \*.vh, which causes
 collisions with v files.

--- a/syntax/vlang.vim
+++ b/syntax/vlang.vim
@@ -44,6 +44,12 @@ endif
 if !exists('g:v_highlight_trailing_whitespace_error')
   let g:v_highlight_trailing_whitespace_error = 1
 endif
+if !exists('g:v_highlight_functions_calls')
+  let g:v_highlight_function_calls = 1
+endif
+if !exists('g:v_highlight_fields')
+  let g:v_highlight_fields = 1
+endif
 
 syn case match
 
@@ -208,6 +214,32 @@ endif
 
 hi def link    	vExtraType         Type
 hi def link    	vSpaceError        Error
+
+" Function calls and Fields are from: https://github.com/fatih/vim-go/blob/master/syntax/go.vim
+" Function calls;
+if v_highlight_function_calls
+  syn match vFunctionCall      /\w\+\ze(/ contains=goBuiltins,goDeclaration
+endif
+hi def link     vFunctionCall      Type
+
+" Fields;
+if v_highlight_fields
+  " 1. Match a sequence of word characters coming after a '.'
+  " 2. Require the following but dont match it: ( \@= see :h E59)
+  "    - The symbols: / - + * %   OR
+  "    - The symbols: [] {} <> )  OR
+  "    - The symbols: \n \r space OR
+  "    - The symbols: , : .
+  " 3. Have the start of highlight (hs) be the start of matched
+  "    pattern (s) offsetted one to the right (+1) (see :h E401)
+  syn match       vField   /\.\w\+\
+        \%(\%([\/\-\+*%]\)\|\
+        \%([\[\]{}<\>\)]\)\|\
+        \%([\!=\^|&]\)\|\
+        \%([\n\r\ ]\)\|\
+        \%([,\:.]\)\)\@=/hs=s+1
+endif
+hi def link    vField              Identifier
 
 " Search backwards for a global declaration to start processing the syntax.
 "syn sync match	vSync grouphere NONE /^\(const\|var\|type\|func\)\>/

--- a/syntax/vlang.vim
+++ b/syntax/vlang.vim
@@ -44,7 +44,7 @@ endif
 if !exists('g:v_highlight_trailing_whitespace_error')
   let g:v_highlight_trailing_whitespace_error = 1
 endif
-if !exists('g:v_highlight_functions_calls')
+if !exists('g:v_highlight_function_calls')
   let g:v_highlight_function_calls = 1
 endif
 if !exists('g:v_highlight_fields')
@@ -218,9 +218,9 @@ hi def link    	vSpaceError        Error
 " Function calls and Fields are from: https://github.com/fatih/vim-go/blob/master/syntax/go.vim
 " Function calls;
 if v_highlight_function_calls
-  syn match vFunctionCall      /\w\+\ze(/ contains=goBuiltins,goDeclaration
+  syn match vFunctionCall      /\w\+\ze(/ contains=vBuiltins,vDeclaration
 endif
-hi def link     vFunctionCall      Type
+hi def link     vFunctionCall      Special
 
 " Fields;
 if v_highlight_fields


### PR DESCRIPTION
Add option to highlight methods (function calls) and/or object fields, so:

```go
// free highlighted:
req.free('test')

// headers highlighted:
req.headers
```
It is rip off from [vim-go](https://github.com/fatih/vim-go/blob/master/syntax/go.vim).

Added configuration for it and documentation in README.md for all current options.