### PR TITLE
Fix autofmt for current vlang

### DIFF
--- a/ftplugin/vlang.vim
+++ b/ftplugin/vlang.vim
@@ -13,7 +13,7 @@ endif
 
 function! _VFormatFile()
 	if exists('g:v_autofmt_bufwritepre') && g:v_autofmt_bufwritepre || exists('b:v_autofmt_bufwritepre') && b:v_autofmt_bufwritepre
-		let substitution = system("v fmt -", join(getline(1, line('$')), "\n"))
+		let substitution = system("v fmt " . expand("%"))
 		if v:shell_error != 0
 			echoerr "While formatting the buffer via vfmt, the following error occurred:"
 			echoerr printf("ERROR(%d): %s", v:shell_error, substitution)


### PR DESCRIPTION
Looks like `v fmt -` is no longer supported, quick fix to change the command to pass the file name.