### PR TITLE
Don't append trailing newline when formatting.

### DIFF
--- a/ftplugin/vlang.vim
+++ b/ftplugin/vlang.vim
@@ -20,7 +20,7 @@ function! _VFormatFile()
 		else
 			let [_, lnum, colnum, _] = getpos('.')
 			%delete
-			call append(0, split(substitution, "\n"))
+			call setline(1, split(substitution, "\n"))
 			call cursor(lnum, colnum)
 		endif
 	endif


### PR DESCRIPTION
Fixes #20.

`%delete` will leave the file containing a single newline.
`append(0, text)` will insert text before the remaining newline, pushing
that newline to the end of the file.
`setline` replaces the contents of the buffer instead.