### PR TITLE
Highlight optional builtin types.

### DIFF
--- a/syntax/vlang.vim
+++ b/syntax/vlang.vim
@@ -88,6 +88,7 @@ hi def link     vCodeGen            Identifier
 
 " Predefined types
 syn keyword     vType               chan map bool string error voidptr
+syn match       vOptionalType       "\%(\<?\)\@<=\(chan\|map\|bool\|string\|error\|voidptr\)"
 syn keyword     vSignedInts         int i8 i16 i64 rune intptr
 syn keyword     vUnsignedInts       byte u16 u32 u64 byteptr
 syn keyword     vFloats             f32 f64 floatptr
@@ -95,6 +96,7 @@ syn keyword     vFloats             f32 f64 floatptr
 " syn keyword    	vComplexes          complex64 complex128
 
 hi def link     vType               Type
+hi def link     vOptionalType       Type
 hi def link     vSignedInts         Type
 hi def link     vUnsignedInts       Type
 hi def link     vFloats             Type


### PR DESCRIPTION
Previously, `string` was highlighted, but `?string` was not.
Now the `string` in `?string` is highlighted (but the ? is left
un-highlighted, so it stands out from the type).

See: https://rebbemalachi.blogspot.com/2017/12/re-highlighting-prefixed-keywords_17.html

before:
![1622403866](https://user-images.githubusercontent.com/2496231/120117994-2c584100-c15e-11eb-9ff0-1ad29ae017ca.png)

after:
![1622403764](https://user-images.githubusercontent.com/2496231/120117993-2c584100-c15e-11eb-8d37-b52a2930dd80.png)
