### PR TITLE
fix wrong hilighting of raw string

### DIFF
--- a/syntax/vlang.vim
+++ b/syntax/vlang.vim
@@ -156,8 +156,8 @@ syn cluster     vStringGroup        contains=@vCharacterGroup,vStringError
 syn region      vString             start=+"+ skip=+\\\\\|\\'+ end=+"+ contains=@vStringGroup
 syn region      vString             start=+'+ skip=+\\\\\|\\'+ end=+'+ contains=@vStringGroup
 
-syn region      vRawString          start=+r"+ skip=+\\\\\|\\'+ end=+"+
-syn region      vRawString          start=+r'+ skip=+\\\\\|\\'+ end=+'+
+syn region      vRawString          start=+r"+ end=+"+
+syn region      vRawString          start=+r'+ end=+'+
 
 hi def link     vString             String
 hi def link     vRawString          String


### PR DESCRIPTION
current `skip` for raw string literal is wrong. It breaks highlight

[![Image from Gyazo](https://i.gyazo.com/98fa3e1ab9501a3508c4c0c328a98d63.png)](https://gyazo.com/98fa3e1ab9501a3508c4c0c328a98d63)