### PR TITLE
highlight backquote in rune literal correctly

### DIFF
--- a/syntax/vlang.vim
+++ b/syntax/vlang.vim
@@ -132,7 +132,7 @@ hi def link     vComment            Comment
 " V escapes
 syn match       vStringVar          display contained +\$[0-9A-Za-z\._]*\([(][^)]*[)]\)\?+
 syn match       vStringVar          display contained "\${[^}]*}"
-syn match       vStringSpeChar      display contained +\\[abfnrtv\\'"]+
+syn match       vStringSpeChar      display contained +\\[abfnrtv\\'"`]+
 syn match       vStringX            display contained "\\x\x\{1,2}"
 syn match       vStringU            display contained "\\u\x\{4}"
 syn match       vStringBigU         display contained "\\U\x\{8}"


### PR DESCRIPTION
Before:

[![Image from Gyazo](https://i.gyazo.com/c689f74c237c5446e6eee63a563af451.png)](https://gyazo.com/c689f74c237c5446e6eee63a563af451)

After:

[![Image from Gyazo](https://i.gyazo.com/1ae4e05752cd372d0d557491e9f39885.png)](https://gyazo.com/1ae4e05752cd372d0d557491e9f39885)