### PR TITLE
set filetype for v.mod

### DIFF
--- a/ftdetect/vlang.vim
+++ b/ftdetect/vlang.vim
@@ -3,3 +3,10 @@ au BufNewFile,BufRead *.v set filetype=vlang
 au BufNewFile,BufRead *.vv set filetype=vlang
 " Support for v scripts
 au BufNewFile,BufRead *.vsh set filetype=vlang
+
+
+au BufNewFile,BufRead *.mod {
+  if expand('%:t') == 'v.mod'
+    set filetype=vmod
+  endif
+}


### PR DESCRIPTION
By default, syntax highlight is wrong for "v.mod" because filetype of  "v.mod"  is modsim3.

No syntax highlight is better than wrong syntax highlight.