### PR TITLE
Format only vlang files

### DIFF
--- a/ftplugin/vlang.vim
+++ b/ftplugin/vlang.vim
@@ -12,6 +12,9 @@ else
 endif
 
 function! _VFormatFile()
+  if &ft != 'vlang' 
+    return
+  endif
 	if exists('g:v_autofmt_bufwritepre') && g:v_autofmt_bufwritepre || exists('b:v_autofmt_bufwritepre') && b:v_autofmt_bufwritepre
 		let substitution = system("v fmt -", join(getline(1, line('$')), "\n"))
 		if v:shell_error != 0


### PR DESCRIPTION
The save function triggers the format function for any `v` file (e.g. vlang or verilog).

As the example below has a defined file type, I expected the command `vfrm` should not be called.

```vim
module hello;
  initial
    begin
      $display("Hello, World");
      $finish
    end
endmodule

// vim: ft=verilog
```

But instead, I got the following error:

```
__vtool_tmp__.1716204697hello.v:2:3: error: unexpected name `initial`
    1 | module hello;
    2 |   initial
      |   ~~~~~~~
    3 |     begin
    4 |       $display("Hello, World");

Internal vfmt error while formatting file: ./__vtool_tmp__.1716204697hello.v.
Encountered a total of: 1 errors.
"hello.v" 9L, 118B written
```
